### PR TITLE
投稿に文字数表示機能を追加

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -77,6 +77,10 @@ class Post < ApplicationRecord
     saved_change_to_published? && published?
   end
 
+  def word_count
+    body&.length || 0
+  end
+
   private
 
   def navigation_scope(current_user)

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -28,6 +28,12 @@
           公開日時未設定
         <% end %>
       </div>
+      <div class="flex items-center">
+        <svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path>
+        </svg>
+        <%= post.word_count %> 文字
+      </div>
       <% unless show_body %>
         <div class="flex items-center">
           <svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 投稿の単語数を表示する機能が追加されました。各投稿に単語数をカウント表示し、アイコン付きの要素が投稿ヘッダーに表示されるようになりました。投稿の内容量を一目で確認できます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->